### PR TITLE
[chore] : CORS 정책 수정 - 프론트엔드 요청 허용 (#25)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -32,7 +32,7 @@ jobs:
           echo "${{ secrets.APPLICATION_CORE_LOCAL_YML }}" | base64 -d > ./core/src/main/resources/application-core-local.yml          
 
       # 4. firebase_account.json 생성
-      - name : Generate firebase_account.json
+      - name: Generate firebase_account.json
         run: |
           mkdir -p ./core/src/main/resources/firebase
           echo "${{ secrets.FIREBASE_ACCOUNT }}" | base64 -d > ./core/src/main/resources/firebase/firebase_account.json
@@ -80,7 +80,7 @@ jobs:
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}
-          password: ${{ secrets.EC2_PASSWORD }}
+          key: ${{ secrets.EC2_SSH_PRIVATE_KEY }}
           port: ${{ secrets.EC2_PORT }}
           source: "Dockerfile,docker-compose.yml,.env"
           target: "~/compose/"
@@ -91,9 +91,9 @@ jobs:
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}
-          password: ${{ secrets.EC2_PASSWORD }}
+          key: ${{ secrets.EC2_SSH_PRIVATE_KEY }}
           port: ${{ secrets.EC2_PORT }}
-          script: |                        
+          script: |
             mkdir -p ~/compose
             cd ~/compose
             docker-compose down

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -1,24 +1,30 @@
 dependencies {
+    // --- Core 모듈 ---
     implementation project(path: ':core')
     testImplementation(testFixtures(project(':core')))
 
+    // --- Spring Boot Starters ---
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
-    //swagger
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
-    // FCM 알림
-    implementation 'com.google.firebase:firebase-admin:9.2.0'
-    // 로컬 캐시
     implementation 'org.springframework.boot:spring-boot-starter-cache'
-    implementation("com.github.ben-manes.caffeine:caffeine:3.1.8")
 
-    tasks.named('bootJar') {
-        enabled = true
-    }
+    // --- Swagger (OpenAPI) ---
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
 
-    tasks.named('jar') {
-        enabled = true
-    }
+    // --- FCM (Firebase) ---
+    implementation 'com.google.firebase:firebase-admin:9.2.0'
+
+    // --- Local Cache (Caffeine) ---
+    implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
+}
+
+// --- 빌드 설정 ---
+tasks.named('bootJar') {
+    enabled = true
+}
+
+tasks.named('jar') {
+    enabled = true
 }

--- a/api/src/main/java/dev/handsup/common/config/SwaggerConfig.java
+++ b/api/src/main/java/dev/handsup/common/config/SwaggerConfig.java
@@ -1,6 +1,6 @@
 package dev.handsup.common.config;
 
-import static org.springframework.http.HttpHeaders.*;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 import java.util.List;
 
@@ -17,41 +17,41 @@ import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 
 @OpenAPIDefinition(
-	info = @Info(
-		title = "Hands-Up API",
-		description = "경매 중고 거래 API 명세서",
-		version = "v.0.1"),
-	servers = {
-		@Server(url = "https://handssup.shop", description = "Default Server URL"),
-		@Server(url = "http://localhost:8080")
-	}
+    info = @Info(
+        title = "Hands-Up API",
+        description = "경매 중고 거래 API 명세서",
+        version = "v.0.1"),
+    servers = {
+        @Server(url = "http://localhost:8080", description = "Default Server URL")
+    }
 )
+
 @Configuration
 public class SwaggerConfig {
 
-	@Bean
-	public OpenAPI openAPI() {
-		SecurityScheme securityScheme = new SecurityScheme()
-			.type(SecurityScheme.Type.HTTP)
-			.scheme("bearer")
-			.bearerFormat("JWT")
-			.in(SecurityScheme.In.HEADER)
-			.name(AUTHORIZATION);
+    @Bean
+    public OpenAPI openAPI() {
+        SecurityScheme securityScheme = new SecurityScheme()
+            .type(SecurityScheme.Type.HTTP)
+            .scheme("bearer")
+            .bearerFormat("JWT")
+            .in(SecurityScheme.In.HEADER)
+            .name(AUTHORIZATION);
 
-		SecurityRequirement securityRequirement = new SecurityRequirement().addList(AUTHORIZATION);
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(AUTHORIZATION);
 
-		return new OpenAPI()
-			.components(new Components().addSecuritySchemes(AUTHORIZATION, securityScheme))
-			.security(List.of(securityRequirement));
-	}
+        return new OpenAPI()
+            .components(new Components().addSecuritySchemes(AUTHORIZATION, securityScheme))
+            .security(List.of(securityRequirement));
+    }
 
-	@Bean
-	public GroupedOpenApi chatOpenApi() {
-		String[] paths = {"/api/**"};
+    @Bean
+    public GroupedOpenApi chatOpenApi() {
+        String[] paths = {"/api/**"};
 
-		return GroupedOpenApi.builder()
-			.group("API v.0.1")
-			.pathsToMatch(paths)
-			.build();
-	}
+        return GroupedOpenApi.builder()
+            .group("API v.0.1")
+            .pathsToMatch(paths)
+            .build();
+    }
 }

--- a/api/src/main/java/dev/handsup/common/config/WebConfig.java
+++ b/api/src/main/java/dev/handsup/common/config/WebConfig.java
@@ -2,30 +2,44 @@ package dev.handsup.common.config;
 
 import java.util.List;
 
+import lombok.RequiredArgsConstructor;
+
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import dev.handsup.auth.jwt.JwtAuthorizationArgumentResolver;
 import dev.handsup.auth.jwt.JwtInterceptor;
-import lombok.RequiredArgsConstructor;
 
 @Configuration
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
 
-	private final JwtAuthorizationArgumentResolver jwtAuthorizationArgumentResolver;
-	private final JwtInterceptor jwtInterceptor;
+    private final JwtAuthorizationArgumentResolver jwtAuthorizationArgumentResolver;
+    private final JwtInterceptor jwtInterceptor;
 
-	@Override
-	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
-		argumentResolvers.add(jwtAuthorizationArgumentResolver);
-	}
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+        argumentResolvers.add(jwtAuthorizationArgumentResolver);
+    }
 
-	@Override
-	public void addInterceptors(InterceptorRegistry registry) {
-		registry.addInterceptor(jwtInterceptor)
-			.addPathPatterns("/api/**");
-	}
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(jwtInterceptor)
+            .addPathPatterns("/api/**");
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+            .allowedOrigins(
+                "http://localhost:8080",
+                "https://localhost:8080"
+            )
+            .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+            .allowedHeaders("*")
+            .allowCredentials(true); // 쿠키/인증 헤더 사용 허용
+    }
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,62 +1,66 @@
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-//    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-//    implementation 'org.springframework.boot:spring-boot-starter-security'
+    // --- Spring Boot Starter ---
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-    runtimeOnly 'com.mysql:mysql-connector-j'
-//    testImplementation 'org.springframework.security:spring-security-test'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.9.2'
-
-    //redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-    // 패스워드 암호화
-    implementation group: 'org.mindrot', name: 'jbcrypt', version: '0.4'
-    // JWT
+
+    // --- Database ---
+    runtimeOnly 'com.mysql:mysql-connector-j'
+
+    // --- Security & 암호화 ---
+    implementation 'org.mindrot:jbcrypt:0.4' // 비밀번호 해시
+    // spring-security, oauth2-client 나중에 필요하면 추가.
+
+    // --- JWT ---
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
-    //redisson
-    implementation group: 'org.redisson', name: 'redisson-spring-boot-starter', version: '3.25.1'
+    // --- Local Cache (Caffeine) ---
+    implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
 
-    // testFixtures 의존성
-    testFixturesImplementation 'jakarta.persistence:jakarta.persistence-api:3.1.0'
-    testFixturesImplementation 'org.springframework:spring-tx:6.1.1'
-    testFixturesImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testFixturesImplementation "org.testcontainers:junit-jupiter:1.19.5"
-    testFixturesImplementation "org.testcontainers:testcontainers:1.19.5"
-    testFixturesImplementation "org.testcontainers:mysql:1.19.2" //mysql test container
+    // --- Redis (Redisson) ---
+    implementation 'org.redisson:redisson-spring-boot-starter:3.25.1'
 
-    testFixturesCompileOnly 'org.projectlombok:lombok'
-    testFixturesAnnotationProcessor 'org.projectlombok:lombok'
-    testFixturesCompileOnly 'org.springframework.boot:spring-boot-starter-security'
+    // --- AWS S3 ---
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
-    // QueryDsl
+    // --- FCM (Firebase) ---
+    implementation 'com.google.firebase:firebase-admin:9.2.0'
+
+    // --- Kafka ---
+    implementation 'org.springframework.kafka:spring-kafka'
+
+    // --- QueryDSL ---
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
-    //s3
-    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
-
-    // FCM 알림
-    implementation 'com.google.firebase:firebase-admin:9.2.0'
-
-    // kafka
-    implementation 'org.springframework.kafka:spring-kafka'
+    // --- 테스트 ---
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.9.2'
+    // spring-security-test는 주석 처리된 상태
+    testFixturesImplementation 'jakarta.persistence:jakarta.persistence-api:3.1.0'
+    testFixturesImplementation 'org.springframework:spring-tx:6.1.1'
+    testFixturesImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testFixturesImplementation 'org.testcontainers:junit-jupiter:1.19.5'
+    testFixturesImplementation 'org.testcontainers:testcontainers:1.19.5'
+    testFixturesImplementation 'org.testcontainers:mysql:1.19.2'
+    testFixturesCompileOnly 'org.projectlombok:lombok'
+    testFixturesAnnotationProcessor 'org.projectlombok:lombok'
+    testFixturesCompileOnly 'org.springframework.boot:spring-boot-starter-security'
 }
 
 // Querydsl
 def generated = 'src/main/generated'
 
-// querydsl QClass 파일 생성 위치를 지정
+// QClass 생성 디렉터리 설정
 tasks.withType(JavaCompile) {
     options.getGeneratedSourceOutputDirectory().set(file(generated))
 }
 
-// java source set 에 querydsl QClass 위치 추가
+// java source set 에 Querydsl QClass 위치 추가
 sourceSets {
     main.java.srcDirs += [generated]
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,24 +1,4 @@
 services:
-  zookeeper:
-    image: wurstmeister/zookeeper
-    container_name: hands-up-zookeeper
-    ports:
-      - "2181:2181"
-
-  kafka:
-    image: wurstmeister/kafka
-    container_name: hands-up-kafka
-    ports:
-      - "9092:9092"
-    environment:
-      KAFKA_ZOOKEEPER_CONNECT: hands-up-zookeeper:2181
-      KAFKA_LISTENERS: INSIDE://0.0.0.0:9092,OUTSIDE://0.0.0.0:29092
-      KAFKA_ADVERTISED_LISTENERS: INSIDE://hands-up-kafka:9092,OUTSIDE://localhost:29092
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT
-      KAFKA_INTER_BROKER_LISTENER_NAME: INSIDE
-    depends_on:
-      - zookeeper
-
   redis:
     image: redis:latest
     container_name: hands-up-redis


### PR DESCRIPTION
### ✨ 작업 내용 요약

1. `CORS 정책 수정 - 프론트엔드 요청 허용`
- / 이하 모든 경로(/**)에 대해 CORS 허용
- 허용 Origin 추가: https://localhost:8080
- 허용 HTTP 메서드: GET, POST, PUT, DELETE, OPTIONS
- 모든 요청 헤더 허용(allowedHeaders("*"))
- 인증 정보(쿠키, Authorization 헤더 등) 사용 허용(allowCredentials(true))
- 운영환경에서는 Origin을 제한하거나, 더 안전한 CORS 설정이 필요할 수 있음.
<br>


### 🔗 관련 이슈

- close #25 
<br>

### 🔍 중점적으로 리뷰 할 부분

-
