### PR TITLE
[fix] : 경매추천 API 에서 LazyInitializationException 발생 - product.images join 추가 (#30)

### DIFF
--- a/core/src/main/java/dev/handsup/auction/repository/auction/AuctionQueryRepositoryImpl.java
+++ b/core/src/main/java/dev/handsup/auction/repository/auction/AuctionQueryRepositoryImpl.java
@@ -65,7 +65,7 @@ public class AuctionQueryRepositoryImpl implements AuctionQueryRepository {
     @Override
     public Slice<Auction> sortAuctionByCriteria(String si, String gu, String dong,
         Pageable pageable) {
-        List<Auction> content = queryFactory.select(QAuction.auction)
+        List<Auction> content = queryFactory.select(QAuction.auction).distinct()
             .from(auction)
             .join(auction.product, product).fetchJoin()
             .leftJoin(product.images).fetchJoin()

--- a/core/src/main/java/dev/handsup/auction/repository/auction/AuctionQueryRepositoryImpl.java
+++ b/core/src/main/java/dev/handsup/auction/repository/auction/AuctionQueryRepositoryImpl.java
@@ -68,6 +68,7 @@ public class AuctionQueryRepositoryImpl implements AuctionQueryRepository {
         List<Auction> content = queryFactory.select(QAuction.auction)
             .from(auction)
             .join(auction.product, product).fetchJoin()
+            .leftJoin(product.images).fetchJoin()
             .where(
                 auction.status.eq(AuctionStatus.BIDDING),
                 siEq(si),


### PR DESCRIPTION
### ✨ 작업 내용 요약

1. `경매추천 API 에서 LazyInitializationException 발생 - product.images join 추가`

`AuctionCacheServiceTest`에서 테스트 시나리오 중 `AuctionMapper.toRecommendAuctionResponse(auction1)`에서 `LazyInitializationException` 발생.

`원인 분석`
- auction.product까지만 fetchJoin 해오고, product.images는 조인 자체를 안 함.
  - 즉, auction만 조회 → product는 바로 채워짐 → 근데 product의 images는 여전히 Lazy Proxy 상태.
  - 그래서 product.getImages() 하는 순간 세션이 필요했고
  - 세션은 이미 닫혀있었으니까 바로 터짐.
<br>

### 🔗 관련 이슈

- close #30 
<br>

### 🔍 중점적으로 리뷰 할 부분

-
