### PR TITLE
[chore] : GC 로그를 수집하기 위해 Java 실행 옵션을 Dockerfile에 추가 (#34)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,9 +29,11 @@ services:
 
   app:
     image: ${DOCKERHUB_USERNAME}/${DOCKERHUB_APP_NAME}:latest
-#    build:
-#      context: .
-#      dockerfile: Dockerfile
+    #    build:
+    #      context: .
+    #      dockerfile: Dockerfile
+    volumes:
+      - ./gc-logs:/logs
     container_name: hands-up-app
     ports:
       - "8080:8080"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,4 +3,6 @@
 /usr/local/bin/wait-for-it.sh hands-up-mysql:3306 -t 40
 
 # 준비되면 애플리케이션 실행
-exec java -jar /app/app.jar
+exec java \
+  -Xlog:gc*:file=/logs/gc.log:time \
+  -jar /app/app.jar


### PR DESCRIPTION
### ✨ 작업 내용 요약

1. `GC 로그를 수집하기 위해 Java 실행 옵션을 Dockerfile에 추가`
- Spring Boot 애플리케이션의 GC 로그를 수집하기 위해 Java 실행 옵션을 Dockerfile에 추가
  - `-Xlog:gc*:file=/logs/gc.log:time`
  - 정확히는 Dockerfile에서 실행하는 `entrypoint.sh` 스크립트에 추가 (jar 실행 커맨드가 있는 곳)
- 수집된 로그 파일을 EC2에서도 확인할 수 있도록 docker-compose에 ./gc-logs:/logs 볼륨 바인딩 추가
- 컨테이너 재빌드 및 GC 로그 정상 출력 여부 확인
<br>

### 🔗 관련 이슈

- close #34 
<br>

### 🔍 중점적으로 리뷰 할 부분

-
