### PR TITLE
[feat] : 경매 추천 리스트 조회 API에서 fetch join을 제거하고 DTO로 필요한 필드만 조회하도록 개선 (#32)

### DIFF
--- a/api/src/test/java/dev/handsup/auction/controller/AuctionApiControllerTest.java
+++ b/api/src/test/java/dev/handsup/auction/controller/AuctionApiControllerTest.java
@@ -158,11 +158,9 @@ class AuctionApiControllerTest extends ApiTestSupport {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.size").value(2))
             .andExpect(jsonPath("$.content[0].auctionId").value(auction2.getId()))
-            .andExpect(jsonPath("$.content[0].endDate").value(
-                auction2.getEndDate().atStartOfDay().toString()))
+            .andExpect(jsonPath("$.content[0].endDate").value(auction2.getEndDate().toString()))
             .andExpect(jsonPath("$.content[1].auctionId").value(auction1.getId()))
-            .andExpect(jsonPath("$.content[1].endDate").value(
-                auction1.getEndDate().atStartOfDay().toString()))
+            .andExpect(jsonPath("$.content[1].endDate").value(auction1.getEndDate().toString()))
             .andExpect(jsonPath("$.hasNext").value(false));
     }
 

--- a/core/src/main/java/dev/handsup/auction/repository/auction/AuctionQueryRepository.java
+++ b/core/src/main/java/dev/handsup/auction/repository/auction/AuctionQueryRepository.java
@@ -8,13 +8,17 @@ import org.springframework.data.domain.Slice;
 import dev.handsup.auction.domain.Auction;
 import dev.handsup.auction.domain.product.product_category.ProductCategory;
 import dev.handsup.auction.dto.request.AuctionSearchCondition;
+import dev.handsup.auction.dto.response.RecommendAuctionResponse;
 
 public interface AuctionQueryRepository {
-	Slice<Auction> searchAuctions(AuctionSearchCondition auctionSearchCondition, Pageable pageable);
 
-	Slice<Auction> sortAuctionByCriteria(String si, String gu, String dong, Pageable pageable);
+    Slice<Auction> searchAuctions(AuctionSearchCondition auctionSearchCondition, Pageable pageable);
 
-	Slice<Auction> findByProductCategories(List<ProductCategory> productCategories, Pageable pageable);
+    Slice<RecommendAuctionResponse> sortAuctionByCriteria(String si, String gu, String dong,
+        Pageable pageable);
 
-	void updateAuctionStatusAfterEndDate();
+    Slice<Auction> findByProductCategories(List<ProductCategory> productCategories,
+        Pageable pageable);
+
+    void updateAuctionStatusAfterEndDate();
 }

--- a/core/src/main/java/dev/handsup/auction/repository/auction/AuctionQueryRepositoryImpl.java
+++ b/core/src/main/java/dev/handsup/auction/repository/auction/AuctionQueryRepositoryImpl.java
@@ -17,7 +17,9 @@ import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import dev.handsup.auction.domain.Auction;
@@ -25,8 +27,11 @@ import dev.handsup.auction.domain.QAuction;
 import dev.handsup.auction.domain.auction_field.AuctionStatus;
 import dev.handsup.auction.domain.auction_field.TradeMethod;
 import dev.handsup.auction.domain.product.ProductStatus;
+import dev.handsup.auction.domain.product.QProduct;
+import dev.handsup.auction.domain.product.QProductImage;
 import dev.handsup.auction.domain.product.product_category.ProductCategory;
 import dev.handsup.auction.dto.request.AuctionSearchCondition;
+import dev.handsup.auction.dto.response.RecommendAuctionResponse;
 import dev.handsup.auction.exception.AuctionErrorCode;
 import dev.handsup.common.exception.ValidationException;
 
@@ -58,17 +63,37 @@ public class AuctionQueryRepositoryImpl implements AuctionQueryRepository {
             .limit(pageable.getPageSize() + 1L)
             .offset(pageable.getOffset())
             .fetch();
-        boolean hasNext = hasNext(pageable.getPageSize(), content);
+        boolean hasNext = hasNextAuction(pageable.getPageSize(), content);
         return new SliceImpl<>(content, pageable, hasNext);
     }
 
     @Override
-    public Slice<Auction> sortAuctionByCriteria(String si, String gu, String dong,
+    public Slice<RecommendAuctionResponse> sortAuctionByCriteria(String si, String gu, String dong,
         Pageable pageable) {
-        List<Auction> content = queryFactory.select(QAuction.auction).distinct()
+
+        QAuction auction = QAuction.auction;
+        QProduct product = QProduct.product;
+        QProductImage imageSub = new QProductImage("imageSub");
+
+        List<RecommendAuctionResponse> content = queryFactory
+            .select(Projections.constructor(RecommendAuctionResponse.class,
+                auction.id,
+                auction.title,
+                auction.tradingLocation.dong,
+                auction.currentBiddingPrice,
+                JPAExpressions
+                    .select(imageSub.imageUrl)
+                    .from(imageSub)
+                    .where(imageSub.product.eq(product))
+                    .orderBy(imageSub.id.asc())
+                    .limit(1),  // id가 가장 작은 = 대표 이미지
+                auction.bookmarkCount,
+                auction.biddingCount,
+                auction.createdAt.stringValue(),
+                auction.endDate.stringValue()
+            ))
             .from(auction)
-            .join(auction.product, product).fetchJoin()
-            .leftJoin(product.images).fetchJoin()
+            .join(auction.product, product)
             .where(
                 auction.status.eq(AuctionStatus.BIDDING),
                 siEq(si),
@@ -76,10 +101,12 @@ public class AuctionQueryRepositoryImpl implements AuctionQueryRepository {
                 dongEq(dong)
             )
             .orderBy(recommendAuctionSort(pageable))
-            .limit(pageable.getPageSize() + 1L)
+            .limit(pageable.getPageSize() + 1L) // Slice 페이징
             .offset(pageable.getOffset())
             .fetch();
-        boolean hasNext = hasNext(pageable.getPageSize(), content);
+
+        boolean hasNext = hasNextRecommendAuctionResponse(pageable.getPageSize(), content);
+
         return new SliceImpl<>(content, pageable, hasNext);
     }
 
@@ -96,7 +123,7 @@ public class AuctionQueryRepositoryImpl implements AuctionQueryRepository {
             .limit(pageable.getPageSize() + 1L)
             .offset(pageable.getOffset())
             .fetch();
-        boolean hasNext = hasNext(pageable.getPageSize(), content);
+        boolean hasNext = hasNextAuction(pageable.getPageSize(), content);
         return new SliceImpl<>(content, pageable, hasNext);
     }
 
@@ -195,11 +222,20 @@ public class AuctionQueryRepositoryImpl implements AuctionQueryRepository {
         return null;
     }
 
-    private boolean hasNext(int pageSize, List<Auction> auctions) {
+    private boolean hasNextAuction(int pageSize, List<Auction> auctions) {
         if (auctions.size() <= pageSize) {
             return false;
         }
         auctions.remove(pageSize);
+        return true;
+    }
+
+    private boolean hasNextRecommendAuctionResponse(int pageSize,
+        List<RecommendAuctionResponse> recommendAuctionResponses) {
+        if (recommendAuctionResponses.size() <= pageSize) {
+            return false;
+        }
+        recommendAuctionResponses.remove(pageSize);
         return true;
     }
 }

--- a/core/src/main/java/dev/handsup/auction/service/AuctionCacheService.java
+++ b/core/src/main/java/dev/handsup/auction/service/AuctionCacheService.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Service;
 
 import com.github.benmanes.caffeine.cache.Cache;
 
-import dev.handsup.auction.dto.mapper.AuctionMapper;
 import dev.handsup.auction.dto.response.RecommendAuctionResponse;
 import dev.handsup.auction.exception.AuctionErrorCode;
 import dev.handsup.auction.repository.auction.AuctionQueryRepository;
@@ -54,8 +53,7 @@ public class AuctionCacheService {
 
         // 3. DB 조회
         Slice<RecommendAuctionResponse> auctionSlice = auctionQueryRepository
-            .sortAuctionByCriteria(si, gu, dong, pageable)
-            .map(AuctionMapper::toRecommendAuctionResponse);
+            .sortAuctionByCriteria(si, gu, dong, pageable);
 
         PageResponse<RecommendAuctionResponse> response = CommonMapper.toPageResponse(auctionSlice);
 

--- a/core/src/test/java/dev/handsup/auction/repository/auction/AuctionQueryRepositoryImplTest.java
+++ b/core/src/test/java/dev/handsup/auction/repository/auction/AuctionQueryRepositoryImplTest.java
@@ -23,6 +23,7 @@ import dev.handsup.auction.domain.auction_field.TradeMethod;
 import dev.handsup.auction.domain.product.ProductStatus;
 import dev.handsup.auction.domain.product.product_category.ProductCategory;
 import dev.handsup.auction.dto.request.AuctionSearchCondition;
+import dev.handsup.auction.dto.response.RecommendAuctionResponse;
 import dev.handsup.auction.repository.product.ProductCategoryRepository;
 import dev.handsup.common.support.DataJpaTestSupport;
 import dev.handsup.fixture.AuctionFixture;
@@ -234,21 +235,28 @@ class AuctionQueryRepositoryImplTest extends DataJpaTestSupport {
     @Test
     void sortAuctionByCriteria() {
         //given
-        Auction auction1 = AuctionFixture.auction(category1);
-        ReflectionTestUtils.setField(auction1, "biddingCount", 4);
-        Auction auction2 = AuctionFixture.auction(category1);
-        ReflectionTestUtils.setField(auction2, "biddingCount", 5);
+        String si = "서울시", gu = "서초구", dong1 = "방배동", dong2 = "반포동";
+        Auction auction1 = AuctionFixture.auction(category1, si, gu, dong1);
+        ReflectionTestUtils.setField(auction1, "biddingCount", 2);
+        Auction auction2 = AuctionFixture.auction(category1, si, gu, dong1);
+        ReflectionTestUtils.setField(auction2, "biddingCount", 8);
+        Auction auction3 = AuctionFixture.auction(category1, si, gu, dong2);
+        ReflectionTestUtils.setField(auction3, "biddingCount", 4);
 
-        auctionRepository.saveAll(List.of(auction1, auction2));
+        auctionRepository.saveAll(List.of(auction1, auction2, auction3));
         PageRequest pageRequest1 = PageRequest.of(
             0, 10, Sort.by("BIDDING")
         );
         //when
-        List<Auction> auctions = auctionQueryRepository.sortAuctionByCriteria(null, null, null,
-                pageRequest1)
+        List<RecommendAuctionResponse> recommendAuctionResponses = auctionQueryRepository.sortAuctionByCriteria(
+                si, gu, dong1, pageRequest1)
             .getContent();
         //then
-        assertThat(auctions).containsExactly(auction2, auction1);
+        assertAll(
+            () -> assertThat(recommendAuctionResponses).hasSize(2),
+            () -> assertThat(recommendAuctionResponses.get(0).biddingCount()).isEqualTo(8),
+            () -> assertThat(recommendAuctionResponses.get(1).biddingCount()).isEqualTo(2)
+        );
     }
 
     @DisplayName("[특정 지역 필터 + 북마크순으로 경매를 조회할 수 있다.]")
@@ -257,11 +265,11 @@ class AuctionQueryRepositoryImplTest extends DataJpaTestSupport {
         //given
         String si = "서울시", gu = "서초구", dong1 = "방배동", dong2 = "반포동";
         Auction auction1 = AuctionFixture.auction(category1, si, gu, dong1);
-        ReflectionTestUtils.setField(auction1, "bookmarkCount", 4);
-        Auction auction2 = AuctionFixture.auction(category2, si, gu, dong1);
-        ReflectionTestUtils.setField(auction2, "bookmarkCount", 5);
-        Auction auction3 = AuctionFixture.auction(category2, si, gu, dong2);
-        ReflectionTestUtils.setField(auction2, "bookmarkCount", 5);
+        ReflectionTestUtils.setField(auction1, "bookmarkCount", 2);
+        Auction auction2 = AuctionFixture.auction(category1, si, gu, dong1);
+        ReflectionTestUtils.setField(auction2, "bookmarkCount", 8);
+        Auction auction3 = AuctionFixture.auction(category1, si, gu, dong2);
+        ReflectionTestUtils.setField(auction3, "bookmarkCount", 4);
 
         auctionRepository.saveAll(List.of(auction1, auction2, auction3));
         PageRequest pageRequest1 = PageRequest.of(
@@ -269,11 +277,16 @@ class AuctionQueryRepositoryImplTest extends DataJpaTestSupport {
         );
 
         //when
-        List<Auction> auctions = auctionQueryRepository.sortAuctionByCriteria(si, gu, dong1,
-                pageRequest1)
+        List<RecommendAuctionResponse> recommendAuctionResponses = auctionQueryRepository.sortAuctionByCriteria(
+                si, gu, dong1, pageRequest1)
             .getContent();
+
         //then
-        assertThat(auctions).containsExactly(auction2, auction1);
+        assertAll(
+            () -> assertThat(recommendAuctionResponses).hasSize(2),
+            () -> assertThat(recommendAuctionResponses.get(0).bookmarkCount()).isEqualTo(8),
+            () -> assertThat(recommendAuctionResponses.get(1).bookmarkCount()).isEqualTo(2)
+        );
     }
 
     @DisplayName("[사용자 선호 카테고리에 속하는 해당하는 경매를 북마크순으로 조회할 수 있다.]")

--- a/core/src/test/java/dev/handsup/auction/service/AuctionCacheServiceTest.java
+++ b/core/src/test/java/dev/handsup/auction/service/AuctionCacheServiceTest.java
@@ -26,6 +26,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import com.github.benmanes.caffeine.cache.Cache;
 
 import dev.handsup.auction.domain.Auction;
+import dev.handsup.auction.domain.auction_field.TradingLocation;
 import dev.handsup.auction.dto.mapper.AuctionMapper;
 import dev.handsup.auction.dto.response.RecommendAuctionResponse;
 import dev.handsup.auction.exception.AuctionErrorCode;
@@ -142,7 +143,12 @@ class AuctionCacheServiceTest {
         given(redisTemplate.opsForValue().get(key)).willReturn(null);
         given(auctionQueryRepository.sortAuctionByCriteria(any(), any(), any(), any()))
             .willReturn(
-                new SliceImpl<>(List.of(auction1, auction2), pageable, false));
+                new SliceImpl<>(
+                    List.of(
+                        AuctionMapper.toRecommendAuctionResponse(auction1),
+                        AuctionMapper.toRecommendAuctionResponse(auction2)
+                    ), pageable, false)
+            );
 
         // when
         PageResponse<RecommendAuctionResponse> response = auctionCacheService.getRecommendAuctions(
@@ -164,12 +170,12 @@ class AuctionCacheServiceTest {
     @DisplayName("[정렬 조건이 없으면 예외를 던진다.]")
     void getRecommendAuctions_noSort_throwsException() {
         // when, then
-        assertThatThrownBy(() -> auctionCacheService.getRecommendAuctions(
-            auction1.getTradingLocation().getSi(),
-            auction1.getTradingLocation().getGu(),
-            auction1.getTradingLocation().getDong(),
-            0, 5, null
-        ))
+        TradingLocation tradingLocation = auction1.getTradingLocation();
+        String si = tradingLocation.getSi();
+        String gu = tradingLocation.getGu();
+        String dong = tradingLocation.getDong();
+
+        assertThatThrownBy(() -> auctionCacheService.getRecommendAuctions(si, gu, dong, 0, 5, null))
             .isInstanceOf(NotFoundException.class)
             .hasMessageContaining(AuctionErrorCode.EMPTY_SORT_INPUT.getMessage());
     }


### PR DESCRIPTION
### ✨ 작업 내용 요약

1. `경매 추천 리스트 조회 API에서 fetch join을 제거하고 RecommendAuctionResponse DTO로 필요한 필드만 조회하도록 개선`
- 대표 이미지 URL은 서브쿼리로 추출 (product.images 중 id가 가장 작은 것)
- auction.product.images에 대한 fetch join 제거
- QueryDSL DTO Projection을 활용한 쿼리 작성
<br>

### 🔗 관련 이슈

- close #32 
<br>

### 🔍 중점적으로 리뷰 할 부분

-
