### PR TITLE
feat: DLT 메시지 DB 저장 및 Slack 알림 전송 & Redis 중복체크 장애 대비 DB fallback 로직 등 (#59, #74, #77)

### DIFF
--- a/api/src/test/resources/application.yml
+++ b/api/src/test/resources/application.yml
@@ -39,3 +39,7 @@ cloud:
 
 fcm:
   certification: firebase/firebase_account.json
+
+notification:
+  slack:
+    webhook-url: https://hooks.slack.com/services/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

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,0 +1,19 @@
+plugins {
+    id 'java-library'
+    id 'java-test-fixtures'
+}
+
+dependencies {
+    implementation 'org.projectlombok:lombok:1.18.22'
+
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
+
+    api 'org.slf4j:slf4j-api:2.0.13'
+    api 'com.fasterxml.jackson.core:jackson-databind:2.17.1'
+
+    api 'jakarta.persistence:jakarta.persistence-api:3.1.0'
+    api 'org.hibernate.orm:hibernate-core:6.4.1.Final' // 선택, IDE 인식용
+}

--- a/core/src/main/java/dev/handsup/common/entity/DeadLetterLog.java
+++ b/core/src/main/java/dev/handsup/common/entity/DeadLetterLog.java
@@ -1,0 +1,60 @@
+package dev.handsup.common.entity;
+
+import static jakarta.persistence.EnumType.*;
+import static jakarta.persistence.GenerationType.*;
+import static lombok.AccessLevel.*;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class DeadLetterLog extends TimeBaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "dead_letter_log_id")
+    private Long id;
+
+    @Column(name = "origin_topic")
+    private String originTopic;
+
+    @Lob
+    @Column(name = "payload")
+    private String payload;
+
+    @Column(name = "error_message")
+    private String errorMessage;
+
+    @Column(name = "exception_class")
+    private String exceptionClass;
+
+    @Column(name = "retry_count")
+    private int retryCount;
+
+    @Enumerated(STRING)
+    private DeadLetterStatus status;
+
+    @Builder
+    public DeadLetterLog(String originTopic, String payload, String errorMessage,
+        String exceptionClass, int retryCount, DeadLetterStatus status) {
+        this.originTopic = originTopic;
+        this.payload = payload;
+        this.errorMessage = errorMessage;
+        this.exceptionClass = exceptionClass;
+        this.retryCount = retryCount;
+        this.status = status;
+    }
+
+    public enum DeadLetterStatus {
+        FAILED, RETRYING, SUCCESS
+    }
+}

--- a/core/src/main/java/dev/handsup/common/entity/ProcessedEvent.java
+++ b/core/src/main/java/dev/handsup/common/entity/ProcessedEvent.java
@@ -1,0 +1,19 @@
+package dev.handsup.common.entity;
+
+import static lombok.AccessLevel.*;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class ProcessedEvent extends TimeBaseEntity {
+
+    @Id
+    @Column(name = "event_id")
+    private String eventId;
+}

--- a/core/src/main/java/dev/handsup/common/repository/DeadLetterLogRepository.java
+++ b/core/src/main/java/dev/handsup/common/repository/DeadLetterLogRepository.java
@@ -1,0 +1,11 @@
+package dev.handsup.common.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import dev.handsup.common.entity.DeadLetterLog;
+
+@Repository
+public interface DeadLetterLogRepository extends JpaRepository<DeadLetterLog, Long> {
+
+}

--- a/core/src/main/java/dev/handsup/common/repository/ProcessedEventLogRepository.java
+++ b/core/src/main/java/dev/handsup/common/repository/ProcessedEventLogRepository.java
@@ -1,0 +1,12 @@
+package dev.handsup.common.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import dev.handsup.common.entity.ProcessedEvent;
+
+@Repository
+public interface ProcessedEventLogRepository extends JpaRepository<ProcessedEvent, Long> {
+
+    boolean existsByEventId(String eventId);
+}

--- a/core/src/main/java/dev/handsup/common/service/RedisDuplicateChecker.java
+++ b/core/src/main/java/dev/handsup/common/service/RedisDuplicateChecker.java
@@ -1,5 +1,7 @@
 package dev.handsup.common.service;
 
+import static java.lang.Boolean.*;
+
 import java.time.Duration;
 
 import lombok.RequiredArgsConstructor;
@@ -15,20 +17,20 @@ import dev.handsup.common.util.KeyGenerator;
 @RequiredArgsConstructor
 public class RedisDuplicateChecker {
 
-    private static final long TTL = 60 * 5L; // 5분
+    private static final long TTL = 60 * 30L; // 30분
     private final StringRedisTemplate redisTemplate;
 
-    public boolean isDuplicate(String eventId) {
+    public boolean checkDuplicateAndCacheIfAbsent(String eventId) {
         String key = KeyGenerator.generateBiddingEventKey(eventId);
-        Boolean success = redisTemplate.opsForValue()
+        Boolean isNewKeyCreated = redisTemplate.opsForValue()
             .setIfAbsent("event:" + eventId, "1", Duration.ofSeconds(TTL));
 
-        if (Boolean.TRUE.equals(success)) {
-            log.debug("✅ Redis key created: {}", key);
+        if (TRUE.equals(isNewKeyCreated)) {
+            log.debug("Redis 키 생성 완료: key={}", key);
         } else {
-            log.debug("🚨 Redis key already exists (duplicate): {}", key);
+            log.info("Redis 키 중복: key={}", key);
         }
 
-        return success == Boolean.FALSE; // 이미 있으면 true
+        return FALSE.equals(isNewKeyCreated);
     }
 }

--- a/core/src/main/java/dev/handsup/common/service/SlackNotificationService.java
+++ b/core/src/main/java/dev/handsup/common/service/SlackNotificationService.java
@@ -1,0 +1,36 @@
+package dev.handsup.common.service;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Service
+public class SlackNotificationService {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final String webhookUrl;
+
+    public SlackNotificationService(@Value("${notification.slack.webhook-url}") String webhookUrl) {
+        this.webhookUrl = webhookUrl;
+    }
+
+    public void send(String message) {
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+
+            String payload = String.format("{\"text\": \"%s\"}", message);
+
+            HttpEntity<String> entity = new HttpEntity<>(payload, headers);
+            restTemplate.postForEntity(webhookUrl, entity, String.class);
+        } catch (Exception e) {
+            log.error("Slack notifications failed to send: {}", e);
+        }
+    }
+}

--- a/core/src/test/resources/application.yml
+++ b/core/src/test/resources/application.yml
@@ -31,3 +31,7 @@ cloud:
 
 fcm:
   certification: firebase/firebase_account.json
+
+notification:
+  slack:
+    webhook-url: https://hooks.slack.com/services/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

--- a/event/build.gradle
+++ b/event/build.gradle
@@ -1,8 +1,10 @@
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
     // --- Core 모듈 ---
     implementation project(path: ':core')
+    testImplementation(testFixtures(project(':core')))
 
     // --- Kafka ---
     implementation 'org.springframework.kafka:spring-kafka:3.1.1'

--- a/event/src/main/java/dev/handsup/event/consumer/BiddingEventDispatcher.java
+++ b/event/src/main/java/dev/handsup/event/consumer/BiddingEventDispatcher.java
@@ -1,53 +1,92 @@
 package dev.handsup.event.consumer;
 
+import java.io.IOException;
+import java.net.SocketTimeoutException;
 import java.util.List;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.dao.RecoverableDataAccessException;
+import org.springframework.kafka.KafkaException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.annotation.RetryableTopic;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.stereotype.Component;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import dev.handsup.bidding.event.BiddingEvent;
+import dev.handsup.common.entity.DeadLetterLog;
+import dev.handsup.common.entity.DeadLetterLog.DeadLetterStatus;
+import dev.handsup.common.repository.DeadLetterLogRepository;
+import dev.handsup.common.repository.ProcessedEventLogRepository;
 import dev.handsup.common.service.RedisDuplicateChecker;
+import dev.handsup.common.service.SlackNotificationService;
 import dev.handsup.event.common.EventHandler;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
-@ConditionalOnProperty(name = "event.kafka.enabled", havingValue = "true", matchIfMissing = false)
+@ConditionalOnProperty(name = "event.kafka.enabled", havingValue = "true")
 public class BiddingEventDispatcher {
 
     private static final String BIDDING_TOPIC_NAME = "bidding-events";
     private final List<EventHandler<BiddingEvent>> handlers;
-    private final RedisDuplicateChecker duplicateChecker;
+    private final RedisDuplicateChecker redisDuplicateChecker;
+    private final DeadLetterLogRepository deadLetterLogRepository;
+    private final ProcessedEventLogRepository processedEventLogRepository;
+    private final ObjectMapper objectMapper;
+    private final SlackNotificationService slackNotificationService;
 
     @RetryableTopic(
         attempts = "4", // 최초 1회 + retry 3회
         backoff = @Backoff(
-            delay = 1000, // 1초 후 첫 재시도
+            delay = 2000, // 1초 후 첫 재시도
             multiplier = 2.0, // 이후 2초 → 4초
             maxDelay = 5000 // 최대 5초까지만 delay
         ),
         dltTopicSuffix = ".dlt",
-        autoCreateTopics = "true",
-        include = {RuntimeException.class}, // 대상 예외 지정 (생략 시 모든 Exception),
-        timeout = "40000" // 전체 재시도 타임아웃 제한 (40초)
+        include = {
+            RuntimeException.class,
+            SocketTimeoutException.class,
+            IOException.class,
+            KafkaException.class,
+            RecoverableDataAccessException.class
+        },
+        timeout = "12000" // 전체 재시도 타임아웃 제한 (12초)
     )
     @KafkaListener(
         topics = BIDDING_TOPIC_NAME,
         groupId = "bidding-consumer-group",
         containerFactory = "biddingKafkaListenerContainerFactory"
     )
-    public void listen(@Payload BiddingEvent event) {
+    public void listen(
+        @Payload BiddingEvent event,
+        @Header(KafkaHeaders.RECEIVED_TOPIC) String topicName
+    ) {
         String eventId = event.eventId();
-        if (eventId == null || duplicateChecker.isDuplicate(eventId)) {
-            log.warn("🚨 Duplicate or invalid eventId. Skipping processing. eventId={}", eventId);
+        boolean isRetry = topicName.contains("-retry-");
+
+        if (eventId == null) {
+            log.warn("Invalid eventId: null");
             return;
+        }
+
+        if (isDuplicate(eventId)) {
+            if (isRetry) {
+                log.warn("중복 감지 + 재시도 환경 → DLT 유도");
+                throw new RuntimeException("🔥 강제 실패: 재시도 중 중복 감지");
+            } else {
+                log.warn("중복 이벤트 → 무시. eventId={}", eventId);
+                return;
+            }
         }
 
         handlers.stream()
@@ -55,7 +94,7 @@ public class BiddingEventDispatcher {
             .findFirst()
             .ifPresentOrElse(
                 handler -> handler.handle(event),
-                () -> log.warn("🚨 No matching handler found for BiddingEvent. event={}", event)
+                () -> log.warn("No matching handler found for BiddingEvent. event={}", event)
             );
     }
 
@@ -64,8 +103,51 @@ public class BiddingEventDispatcher {
         groupId = "bidding-consumer-group-dlt",
         containerFactory = "biddingKafkaListenerContainerFactory"
     )
-    public void handleDLT(@Payload BiddingEvent event) {
-        log.error("❌ Received message from DLT. event={}", event);
-        // TODO: Elastic에 기록 or DB 저장 등 처리
+    @Transactional
+    public DeadLetterLog handleDLT(
+        @Payload BiddingEvent event,
+        @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
+        @Header(name = "x-exception-class", required = false) String exceptionClass,
+        @Header(name = "x-exception-message", required = false) String exceptionMessage
+    ) throws JsonProcessingException {
+        log.warn("Received message from DLT. event={}", event);
+
+        // 1. DB 저장
+        String jsonPayload = objectMapper.writeValueAsString(event);
+
+        DeadLetterLog deadLetterLog = DeadLetterLog.builder()
+            .originTopic(topic.replace(".dlt", ""))
+            .payload(jsonPayload)
+            .errorMessage(exceptionMessage != null ? exceptionMessage : "No message")
+            .exceptionClass(exceptionClass != null ? exceptionClass : "Unknown")
+            .retryCount(0)
+            .status(DeadLetterStatus.FAILED)
+            .build();
+
+        deadLetterLogRepository.save(deadLetterLog);
+
+        // 2. Slack 알림
+        String truncatedPayload = event.toString(); // 필요시 substring 추가
+        String slackMessage = String.format(
+            "[❗DLT 발생]%n➡️ 예외 클래스: %s%n🧨 에러 메시지: %s%n📦 이벤트 데이터:%n%s",
+            exceptionClass,
+            exceptionMessage != null ? exceptionMessage : "에러 메시지 없음",
+            truncatedPayload.length() > 500 ? truncatedPayload.substring(0, 500) + "..." : truncatedPayload
+        );
+        slackNotificationService.send(slackMessage);
+
+        // 3. ElasticSearch 로그 저장
+
+        return deadLetterLog;
+    }
+
+    private boolean isDuplicate(String eventId) {
+        try {
+            return redisDuplicateChecker.checkDuplicateAndCacheIfAbsent(eventId);
+        } catch (Exception redisEx) {
+            log.warn("Redis 장애로 eventId 중복 체크 실패: eventId={}", eventId);
+        }
+
+        return processedEventLogRepository.existsByEventId(eventId);
     }
 }

--- a/event/src/main/java/dev/handsup/event/consumer/BiddingEventListener.java
+++ b/event/src/main/java/dev/handsup/event/consumer/BiddingEventListener.java
@@ -12,7 +12,7 @@ import dev.handsup.event.producer.BiddingEventProducer;
 
 @Component
 @RequiredArgsConstructor
-@ConditionalOnProperty(name = "event.kafka.enabled", havingValue = "true", matchIfMissing = false)
+@ConditionalOnProperty(name = "event.kafka.enabled", havingValue = "true")
 public class BiddingEventListener {
 
     private final BiddingEventProducer biddingEventProducer;

--- a/event/src/main/java/dev/handsup/event/consumer/KafkaConsumerConfig.java
+++ b/event/src/main/java/dev/handsup/event/consumer/KafkaConsumerConfig.java
@@ -21,7 +21,7 @@ import dev.handsup.bidding.event.BiddingEvent;
 
 @EnableKafka
 @Configuration
-@ConditionalOnProperty(name = "event.kafka.enabled", havingValue = "true", matchIfMissing = false)
+@ConditionalOnProperty(name = "event.kafka.enabled", havingValue = "true")
 public class KafkaConsumerConfig {
 
     @Value("${spring.kafka.consumer.bootstrap-servers}")

--- a/event/src/main/java/dev/handsup/event/producer/KafkaProducerConfig.java
+++ b/event/src/main/java/dev/handsup/event/producer/KafkaProducerConfig.java
@@ -17,7 +17,7 @@ import org.springframework.kafka.support.serializer.JsonSerializer;
 import dev.handsup.bidding.event.BiddingEvent;
 
 @Configuration
-@ConditionalOnProperty(name = "event.kafka.enabled", havingValue = "true", matchIfMissing = false)
+@ConditionalOnProperty(name = "event.kafka.enabled", havingValue = "true")
 public class KafkaProducerConfig {
 
     @Value("${spring.kafka.producer.bootstrap-servers}")

--- a/event/src/test/java/dev/handsup/BiddingEventDispatcherTest.java
+++ b/event/src/test/java/dev/handsup/BiddingEventDispatcherTest.java
@@ -1,0 +1,81 @@
+package dev.handsup;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import dev.handsup.auction.domain.Auction;
+import dev.handsup.bidding.domain.Bidding;
+import dev.handsup.bidding.dto.BiddingMapper;
+import dev.handsup.bidding.event.BiddingEvent;
+import dev.handsup.bidding.event.BiddingEvent.BiddingEventType;
+import dev.handsup.common.entity.DeadLetterLog;
+import dev.handsup.common.entity.DeadLetterLog.DeadLetterStatus;
+import dev.handsup.common.repository.DeadLetterLogRepository;
+import dev.handsup.common.service.RedisDuplicateChecker;
+import dev.handsup.common.service.SlackNotificationService;
+import dev.handsup.event.common.EventHandler;
+import dev.handsup.event.consumer.BiddingEventDispatcher;
+import dev.handsup.fixture.AuctionFixture;
+import dev.handsup.fixture.BiddingFixture;
+import dev.handsup.fixture.UserFixture;
+import dev.handsup.user.domain.User;
+
+@DisplayName("[Bidding Event Dispatcher 테스트]")
+@ExtendWith(MockitoExtension.class)
+class BiddingEventDispatcherTest {
+
+    @Mock
+    private List<EventHandler<BiddingEvent>> handlers;
+    @Mock
+    private DeadLetterLogRepository deadLetterLogRepository;
+    @Mock
+    private ObjectMapper objectMapper;
+    @Mock
+    private RedisDuplicateChecker redisDuplicateChecker;
+    @Mock
+    private SlackNotificationService slackNotificationService;
+    @InjectMocks
+    private BiddingEventDispatcher dispatcher;
+
+    @DisplayName("[이벤트를 받으면 DeadLetterLog 를 저장한다.]")
+    @Test
+    void handleDLT() throws Exception {
+        // given
+        User bidder = UserFixture.user1();
+        Auction auction = AuctionFixture.auction();
+        Bidding bidding = BiddingFixture.bidding(auction, bidder);
+        BiddingEvent fakeEvent = BiddingMapper.toBiddingEvent(bidding, BiddingEventType.REGISTERED);
+        String json = "{\"fake\":\"payload\"}";
+
+        given(objectMapper.writeValueAsString(any())).willReturn(json);
+
+        // when
+        String exceptionMessage = "Some error";
+        String exceptionClass = "java.lang.Exception";
+        DeadLetterLog deadLetterLog = dispatcher.handleDLT(fakeEvent, "bidding-events.dlt", exceptionClass,
+            exceptionMessage);
+
+        // then
+        verify(deadLetterLogRepository, times(1)).save(any(DeadLetterLog.class));
+        verify(slackNotificationService, times(1)).send(contains(exceptionMessage));
+        assertAll(
+            () -> assertEquals("bidding-events", deadLetterLog.getOriginTopic()),
+            () -> assertEquals(json, deadLetterLog.getPayload()),
+            () -> assertEquals(exceptionClass, deadLetterLog.getExceptionClass()),
+            () -> assertEquals(exceptionMessage, deadLetterLog.getErrorMessage()),
+            () -> assertEquals(DeadLetterStatus.FAILED, deadLetterLog.getStatus())
+        );
+    }
+
+}

--- a/event/src/test/resources/application.yml
+++ b/event/src/test/resources/application.yml
@@ -1,0 +1,38 @@
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+        default_batch_fetch_size: 10
+  kafka:
+    producer:
+      bootstrap-servers: localhost:9092
+
+logging:
+  level:
+    root: info
+    org.springframework: info
+    org.hibernate: info
+    org.hibernate.SQL: debug
+    org.hibernate.tool.hbm2ddl: debug
+    org.hibernate.type.descriptor.sql.BasicBinder: trace
+
+jwt:
+  secret: prgrmsdevcoursehandsupjsonwebtokensecretkeytest123
+  token-validity-in-seconds: 1800
+cloud:
+  aws:
+    credentials:
+      access-key: s3-access-key
+      secret-key: s3-secret-key
+    region:
+      static: s3-region
+    s3:
+      bucket: s3-bucket-name
+    stack:
+      auto: false
+
+fcm:
+  certification: firebase/firebase_account.json

--- a/event/src/test/resources/firebase/firebase_account.json
+++ b/event/src/test/resources/firebase/firebase_account.json
@@ -1,0 +1,13 @@
+{
+  "type": "service_account",
+  "project_id": "hands-up-6a33b",
+  "private_key_id": "be18aed89999a93794e60111cd621b13d9bced4d",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCr5/Bxl81QUkWj\n+epgIQge7ED4ZwiNN0GV9+g/WxgSaDHfn73o/2nMVp8AbiE7F35HsaW0HPLWRLgY\n932bJ72HzqAA37oMPE69+LVv7qHkZLrpbZP0Q0xJ6GYdDVD3X/mtxb7P6qoYoDUA\n2QgKYjvBtEA8gnvH4YA0Nd93vMUopdnk3tpe1RWFlANL0B8EiSsNJC9hkIpSQml3\nhBpEc6m/+9ndc07xsJCQd0N2Y11JhEq4dEau4upBnqLWFBjFWqM69zd4a5cW/bC9\n7D76ATEttYKj6ye368e44RflmWnfcrvg64I2gdERZTWTXPICbjPGwam18urmwoRu\n8ts81QSHAgMBAAECggEAJ64UhqvjFPjAoW6FBqZpQPYIsy3ZP/tytKKyJbmpr0oE\nxRkS1Y7rRWLzNb62BfVQzUy4soACH6piEkVCZYeBTLFJppn90Gg1Rs17V/htvxHv\nQQVtovLLz72IoIkb2NX7BH0CI+0HUULdqTHvlLIDGB26vBzkZIltNd//kpxsqApr\nhtbiweXialc2Ihnoj/S4klRItxtiNGs/EA0qSPzuCxmBVRP7t8EkZFzg6LdiStNz\niZr7UK11yxApQT1CCd7QGuaGanxiQ/HJndDDwWp0dldFOZBSS8caiDQjPFlkthj5\ns2SHGEdXX57r/5wItLA/Va/5UAWXPjAqZ3lCe9TXrQKBgQDW8+j9qkvYF9xLWpLK\nyLYp/ysSNFbu14N1hVeO3SkI6WKIYK4x5xH5Ky0wibUKfkV9pPOEyC96bSYLi4eV\nQizgTspuqV8VjkgrMgJvwBVEevSP7UjlSYETWSteXmQrR9ncwB3NNdlrej06Spqi\ngDNegVOrUR75PtJWR1FDCrO4JQKBgQDMu6nX2h6JSAUZPB0n7pnA9WL9qOU1PDEH\nrEdlNuwlyrw0s0O7w9vs+Wsv8hDfkkMVuZMjD5TxQVyajO/YkqPolKgHKSY7nsre\naBKidDEXGhJygkhELDU9ejVIEb6Wz53zrLey+aCgbocnTMk+XLRJrQr6cUSPlWJF\nvAH81ZUEOwKBgGuw86/y2+C9w461KAoUmL9dqfSK6Grs6l28mmtm/iIK22S8G0nB\nHM4bBZ7lvyAstyAFvkNuD+tkN8Vc+GadKuKOVvkuPgcMq7eIbJQURhNzDof1N6o4\nM0TATewPmlvcuZfRYJzpN66TJY3IxsRXOmVEoeiY0c3J3ZOAU4QlHnlJAoGAFSiL\n2//xyfREeqAozziscTGrAlYTIhZPZuCaHE65xwoVu0iPhncuYmZAepsEvWZLQpKE\nL0pr9SbxIBPSscot4FqEpwDMr7qwcp3E1z8015NdNrJaL5l2Ax1/JiyXStS4GTfP\nYFLGE+54T0pzPdus0jRs/wb3s/MXTeepOO0F0oMCgYADUP0qgPSa7DIP/bIWEGsI\nK8dnJSf5ghN9DgZqaYujj/jVNehOkPRTvqTh0njD2rsGcplP+msiSp0S+0PQHYJj\nH7FjSMzKRZv456cMFFN4EJ6GANzhOnOcn6n7+2aqnQ2ertyY79B9BLdfJw8DWKzC\nRppXK0rhRCOjBVT39fRluw==\n-----END PRIVATE KEY-----\n",
+  "client_email": "firebase-adminsdk-ie1cy@hands-up-6a33b.iam.gserviceaccount.com",
+  "client_id": "106213486966534531441",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/firebase-adminsdk-ie1cy%40hands-up-6a33b.iam.gserviceaccount.com",
+  "universe_domain": "googleapis.com"
+}


### PR DESCRIPTION
### ✨ 작업 내용 요약

- close #59

`1. 실패 메시지 저장용 dead_letter_log 테이블 생성`

`2. BiddingEventDisPatcher.handleDLT()`
   - 수신한 메시지로 DeadLetterLog를 생성하여 DB에 저장
   - 테스트코드 추가

`3. 실패 메시지 저장 시 Slack 알림도 함께 전송`

`4. RedisDuplicateChecker 코드 정리`

<br>

- close #74 

- Redis 장애 감지 시, ProcessedEvent 테이블을 조회하여 eventId 존재 여부를 확인
- 해당 테이블은 eventId를 Key로 저장

<br>

- close #77

- common, event 모듈에 build.gradle 설정 추가
- 새로 생성한 모듈의 test 디렉토리에도 환경 설정 추가

### 🔍 중점적으로 리뷰 할 부분

-
